### PR TITLE
Stop crashing on emulated devices

### DIFF
--- a/android/src/main/java/com/ibits/react_native_in_app_review/AppReviewModule.java
+++ b/android/src/main/java/com/ibits/react_native_in_app_review/AppReviewModule.java
@@ -45,16 +45,19 @@ public class AppReviewModule extends ReactContextBaseJavaModule {
             request.addOnCompleteListener(task -> {
                 if (task.isSuccessful()) {
                     // We can get the ReviewInfo object
-                    ReviewInfo reviewInfo = task.getResult();
-                    Task<Void> flow = manager.launchReviewFlow(getCurrentActivity(), reviewInfo);
+                    try {
+                        ReviewInfo reviewInfo = task.getResult();
+                        Task<Void> flow = manager.launchReviewFlow(getCurrentActivity(), reviewInfo);
 
-                    flow.addOnCompleteListener(taski -> {
-                        // The flow has finished. The API does not indicate whether the user
-                        // reviewed or not, or even whether the review dialog was shown. Thus, no
-                        // matter the result, we continue our app flow.
-                        Log.e("Review isSuccessful", "" + taski.isSuccessful());
-                    });
-
+                        flow.addOnCompleteListener(taski -> {
+                            // The flow has finished. The API does not indicate whether the user
+                            // reviewed or not, or even whether the review dialog was shown. Thus, no
+                            // matter the result, we continue our app flow.
+                            Log.e("Review isSuccessful", "" + taski.isSuccessful());
+                        });
+                    } catch (Exception e) {
+                        Log.e("getResult may have thrown an exception. This is likely an emulated device.");
+                    }
                 } else {
                     Log.e("Review Error", task.getResult().toString());
                 }

--- a/android/src/main/java/com/ibits/react_native_in_app_review/AppReviewModule.java
+++ b/android/src/main/java/com/ibits/react_native_in_app_review/AppReviewModule.java
@@ -56,7 +56,7 @@ public class AppReviewModule extends ReactContextBaseJavaModule {
                             Log.e("Review isSuccessful", "" + taski.isSuccessful());
                         });
                     } catch (Exception e) {
-                        Log.e("getResult may have thrown an exception. This is likely an emulated device.");
+                        Log.e("Review Error", "getResult may have thrown an exception. This is likely an emulated device.");
                     }
                 } else {
                     Log.e("Review Error", task.getResult().toString());


### PR DESCRIPTION
See https://stackoverflow.com/a/59266755/4554577

getResult() throws an exception, even though isSuccessful() is true which is a false positive. This should prevent it from crashing.