### PR TITLE
Update Podfile

### DIFF
--- a/Example/ios/Podfile
+++ b/Example/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 target 'InAppReview' do
   config = use_native_modules!


### PR DESCRIPTION
Example doesn't work, needs an update to platform. Otherwise, it says this error:

```
Fetching podspec for `glog` from `../node_modules/react-native/third-party-podspecs/glog.podspec`
[!] CocoaPods could not find compatible versions for pod "React-RCTImage":
  In Podfile:
    React-RCTImage (from `../node_modules/react-native/Libraries/Image`)

Specs satisfying the `React-RCTImage (from `../node_modules/react-native/Libraries/Image`)` dependency were found, but they required a higher minimum deployment target.

Aborting run
An unexpected error was encountered. Please report it as a bug:
CocoaPodsError: Command `pod install` failed.
```