### PR TITLE
Error on iOS build with Expo SDK 44 - duplicate interface definition for class 'RCTModuleRegistry'

### DIFF
--- a/ios/RNInAppReviewIOS-Bridging-Header.h
+++ b/ios/RNInAppReviewIOS-Bridging-Header.h
@@ -1,5 +1,1 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif

--- a/ios/RNInAppReviewIOS.m
+++ b/ios/RNInAppReviewIOS.m
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <StoreKit/SKStoreReviewController.h>
 #import <UIKit/UIKit.h>
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RCT_EXTERN_MODULE(RNInAppReviewIOS, NSObject)
 


### PR DESCRIPTION
Fixes error on issue #106 