### PR TITLE
fix: filter scene selection to UIWindowScene

### DIFF
--- a/ios/RNInAppReviewIOS.swift
+++ b/ios/RNInAppReviewIOS.swift
@@ -5,15 +5,19 @@ import StoreKit
 @objc(RNInAppReviewIOS)
 class RNInAppReviewIOS: NSObject {
 
-  @objc 
+  @objc
   func requestReview (_ resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
-      if #available(iOS 14.0, *) {
-        if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
-            SKStoreReviewController.requestReview(in: scene)
-            resolve("true");
-        } else {
-          reject("25","SCENE_DOESN'T_EXIST",nil);
-        }
+    if #available(iOS 14.0, *) {
+      let activeWindowScene = UIApplication.shared.connectedScenes.filter { scene in
+        return scene.activationState == .foregroundActive && scene is UIWindowScene
+      }.first
+
+      if let scene = activeWindowScene as? UIWindowScene {
+        SKStoreReviewController.requestReview(in: scene)
+        resolve("true");
+      } else {
+        reject("25","SCENE_DOESN'T_EXIST",nil);
+      }
     } else if #available(iOS 10.3, *) {
         SKStoreReviewController.requestReview()
         resolve("true");


### PR DESCRIPTION
When starting an app on CarPlay, the scene will be a `CPTemplateApplicationScene`, therefore
the scene selection for presenting the review request should be filtered to `UIWindowScene`.