### PR TITLE
fix: use new appstore api on ios 16 and up

### DIFF
--- a/ios/RNInAppReviewIOS.swift
+++ b/ios/RNInAppReviewIOS.swift
@@ -6,15 +6,24 @@ import StoreKit
 class RNInAppReviewIOS: NSObject {
 
   @objc
-  func requestReview (_ resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
+  func requestReview (_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
     if #available(iOS 14.0, *) {
       let activeWindowScene = UIApplication.shared.connectedScenes.filter { scene in
         return scene.activationState == .foregroundActive && scene is UIWindowScene
       }.first
 
       if let scene = activeWindowScene as? UIWindowScene {
-        SKStoreReviewController.requestReview(in: scene)
-        resolve("true");
+          if #available(iOS 16.0, *) {
+              Task {
+                  await MainActor.run {
+                      AppStore.requestReview(in: scene)
+                      resolve("true");
+                  }
+              }
+          } else {
+            SKStoreReviewController.requestReview(in: scene)
+            resolve("true");
+          }
       } else {
         reject("25","SCENE_DOESN'T_EXIST",nil);
       }


### PR DESCRIPTION
`SKStoreReviewController.requestReview` is deprecated per [apple docs](https://developer.apple.com/documentation/storekit/skstorereviewcontroller/requestreview(in:))

This uses new [requestReview api](https://developer.apple.com/documentation/storekit/appstore/requestreview(in:)-1q8qs) on iOS 16 and up.