### PR TITLE
Replace deprecated usage of SKStoreReviewController

### DIFF
--- a/ios/RNInAppReviewIOS.swift
+++ b/ios/RNInAppReviewIOS.swift
@@ -13,7 +13,11 @@ class RNInAppReviewIOS: NSObject {
       }.first
 
       if let scene = activeWindowScene as? UIWindowScene {
-        SKStoreReviewController.requestReview(in: scene)
+        if #available(iOS 18, *) {
+          AppStore.requestReview(in: scene)
+        } else {
+          SKStoreReviewController.requestReview(in: scene)
+        }
         resolve("true");
       } else {
         reject("25","SCENE_DOESN'T_EXIST",nil);


### PR DESCRIPTION
Use the new [AppStore.requestReview](https://developer.apple.com/documentation/storekit/appstore/requestreview(in:)-1q8qs) API on iOS 18+.

Fixes https://github.com/MinaSamir11/react-native-in-app-review/issues/187